### PR TITLE
Feature:Auto Deploy to gh-page branch when push data branch

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,12 +3,7 @@ name: Node.js CI
 on:   
   push:
     branches:
-      - lagagain
-  # Also trigger on page_build, as well as release created events
-  page_build:
-  release:
-    types: # This configuration does not affect the page_build event above
-      - created
+      - data
 jobs:
   build:
 
@@ -28,12 +23,12 @@ jobs:
     - run: npm run build --if-present\
       env:
         CI: true
-        
+
     - name: GitHub Pages
       uses: crazy-max/ghaction-github-pages@v1.2.5
       with:
           # Build directory to deploy
           build_dir:  ./dist
-          keep_history: true
+          keep_history: false
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,7 +1,14 @@
 name: Node.js CI
 
-on: [push]
-
+on:   
+  push:
+    branches:
+      - lagagain
+  # Also trigger on page_build, as well as release created events
+  page_build:
+  release:
+    types: # This configuration does not affect the page_build event above
+      - created
 jobs:
   build:
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,29 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm run build --if-present\
+      env:
+        CI: true
+        
+    - name: GitHub Pages
+      uses: crazy-max/ghaction-github-pages@v1.2.5
+      with:
+          # Build directory to deploy
+          build_dir:  ./dist

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x,]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,3 +27,5 @@ jobs:
       with:
           # Build directory to deploy
           build_dir:  ./dist
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,4 +31,4 @@ jobs:
           build_dir:  ./dist
           keep_history: false
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PAT: ${{ secrets.GITHUB_PAT }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Deploy to Github(gh-page)
 
 on:   
   push:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,3 +32,4 @@ jobs:
           keep_history: false
       env:
           GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,5 +27,6 @@ jobs:
       with:
           # Build directory to deploy
           build_dir:  ./dist
+          keep_history: true
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ Create a resume by writing a `.yml` file.
     ```
 
 ## Usage
+1.  Create and Checkout New Branch `data`.  Edit you information on the branch.
+2.  Replace my information with yours in `data/en.yml` and `data/zh-TW.yml`
 
-1.  Replace my information with yours in `data/en.yml` and `data/zh-TW.yml`
-
-2.  Each `$name.yml` file will create a **$name** version of resume. In my case, it will be **zh-TW** and **en**.
+3.  Each `$name.yml` file will create a **$name** version of resume. In my case, it will be **zh-TW** and **en**.
 
     Feel free to add a `.yml` file in this folder to create a new version of resume.
 
     ![i18n](./doc/images/i18n.png)
 
-3.  Preview your resume in <http://localhost:1234>
+4.  Preview your resume in <http://localhost:1234>
 
     ```bash
     yarn start
@@ -60,6 +60,13 @@ yarn deploy
 ```
 
 <http://$username.github.io/me>
+
+## Auto Deploy to GitHub Page(gh-page)
+
+If you edit your information on data branch, when you push this branch, will auto deploy Page to gh-page.
+
+But there is a problem([see this issue](https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-531889292)), GitHub team [currently working on it](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869).
+
 
 ## Build With
 

--- a/src/javascripts/vue/components/chapters/experience.vue
+++ b/src/javascripts/vue/components/chapters/experience.vue
@@ -23,7 +23,7 @@
       </p>
       <div class="container">
         <p v-for="sentence in sentences(experience.description)">{{ sentence }}</p>
-        <img v-if="experience.image" :src="experience.image" class="border border-dark">
+        <a v-if="experience.image" :href="experience.link" ><img :src="experience.image" class="border border-dark"></a>
       </div>
       <hr>
     </div>


### PR DESCRIPTION
Add Feature:
- Add link to image(experience chapter)  
- Auto Deploy to gh-page branch when push data branch.
  But there is a problem, you need still click to update GitHub Page on setting now.  About this problem, please see [the issue](https://github.com/crazy-max/ghaction-github-pages/issues/1#issuecomment-531889292), and GitHub team [currently working on it](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869).